### PR TITLE
Add button to send weekly digest email to django admin

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,9 @@ import dj_database_url
 import os
 import sys
 import environ
+import mimetypes
 
+mimetypes.add_type("text/css", ".css", True)
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -45,6 +47,7 @@ DYNAMIC_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "127.0.0.1,localhost").split("
 
 if DEVELOPMENT_MODE:
     STATIC_HOSTS = ['localhost']
+    DEBUG = 'True'
 else:
     STATIC_HOSTS = [os.getenv('CLIENT_HOST')]
 
@@ -165,7 +168,6 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-STATICFILES_DIRS = (os.path.join(BASE_DIR, 'static'),)
 
 MEDIA_URL = 'media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'mediafiles')

--- a/events/admin.py
+++ b/events/admin.py
@@ -20,3 +20,4 @@ class EventAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Event, EventAdmin)
+admin.site.site_header = 'Event Board API dashboard'

--- a/weekly_digest/admin.py
+++ b/weekly_digest/admin.py
@@ -23,7 +23,12 @@ class WeeklyDigestSubscriptionAdmin(admin.ModelAdmin):
       return self.email
 
     def send_email(self, request):
-      trigger_digest_email()
+      email_sent = trigger_digest_email()
+      if (email_sent):
+          self.message_user(request, "✨ The Weekly Digest email was successfully sent to all subscribers!")
+      else:
+          self.message_user(request, "🚨 The Weekly Digest email failed to send")
+
       return HttpResponseRedirect("../")
 
     def get_urls(self):

--- a/weekly_digest/admin.py
+++ b/weekly_digest/admin.py
@@ -1,3 +1,37 @@
 from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
+from django.urls import path
+from django.template.response import TemplateResponse
+from django.http import HttpResponseRedirect
+from weekly_digest.utils import trigger_digest_email
 
-# Register your models here.
+from django.utils.safestring import mark_safe
+
+from weekly_digest.models import WeeklyDigestSubscription
+
+class WeeklyDigestSubscriptionAdmin(admin.ModelAdmin):
+    list_display = (
+      'email',
+      'subscribed',
+    )
+
+    list_filter = ('email', 'subscribed')
+
+    change_list_template = 'admin/weekly_digests/weekly_digests_change_list.html'
+    
+    def identifier(self, _obj):
+      return self.email
+
+    def send_email(self, request):
+      trigger_digest_email()
+      return HttpResponseRedirect("../")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path('send_email/', self.send_email)
+        ]
+        return custom_urls + urls
+    
+    
+admin.site.register(WeeklyDigestSubscription, WeeklyDigestSubscriptionAdmin)

--- a/weekly_digest/templates/admin/weekly_digests/weekly_digests_change_list.html
+++ b/weekly_digest/templates/admin/weekly_digests/weekly_digests_change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+
+{% block object-tools %}
+    <div>
+        <form action="send_email/" method="POST">
+            {% csrf_token %}
+            <button class="button addLink" type="submit">Send Weekly Digest Email</button>
+        </form>
+    </div>
+    {{ block.super }}
+{% endblock%}

--- a/weekly_digest/utils.py
+++ b/weekly_digest/utils.py
@@ -34,9 +34,10 @@ def trigger_digest_email():
                     [email],
                     fail_silently=False,
                     html_message=html_message,)
+                return True
             except BaseException as e:
-                # Is there a better way to report errors?
                 print('Email failed to send: ', e)
+                return False
 
 
 def digest_events():


### PR DESCRIPTION
- Register weekly digest subscriptions to admin
- Add "Send weekly digest email" button to weekly digest admin list view.
- Fix local admin styles not being included

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/11773797/202796276-633ae82d-a8fc-4d66-accc-a1eba31bd615.png">

### To Test:
1. Navigate to http://localhost:8000/admin/
2. Login with your super user (see: readme)
3. Navigate Weekly Digest Subscriptions
4. Click "Send Weekly Digest Email" button
5. See success message
6. View console to see email html printed