### PR TITLE
canada-usa; order region fields by alpha order

### DIFF
--- a/events/management/commands/seed.py
+++ b/events/management/commands/seed.py
@@ -64,14 +64,14 @@ LANGUAGE_MAP = {
 }
 
 REGION_MAP = {
-    "Online": "online",
-    "Canada / USA": "usa-canada",
-    "Europe": "europe",
-    "Asia": "asia",
     "Africa": "africa",
+    "Asia": "asia",
+    "Canada / USA": "canada-usa",
+    "Europe": "europe",
     "Latin America": "latin-america",
     "Middle East": "middle-east",
     "Oceania": "oceania",
+    "Online": "online",
 }
 
 


### PR DESCRIPTION
## Description
Made changes to this file:
https://github.com/data-umbrella/event-board-api/blob/main/events/management/commands/seed.py

1. change `usa-canada` to `canada-usa`
2. order regions by alphabetical order

## References
Closes #53


## To Do
make consistent in event-board-web

